### PR TITLE
Fixed a crash on the #enabled? method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next version
+
+- Fixed crash on nested values on the `#enabled?` method. See [#3](https://github.com/mssola/cconfig/issues/3).
+
 ## 1.1.0
 
 - Added the `disabled?` method, which is a shorthand for `enabled?`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cconfig (1.0.0)
+    cconfig (1.1.0)
       safe_yaml (~> 1.0.0, >= 1.0.0)
 
 GEM

--- a/lib/cconfig/hash_utils.rb
+++ b/lib/cconfig/hash_utils.rb
@@ -31,14 +31,16 @@ module CConfig
       #     b:
       #       enabled: true
       def enabled?(feature)
-        objs = feature.split(".")
-        if objs.length == 2
-          return false if !self[objs[0]][objs[1]] || self[objs[0]][objs[1]].empty?
-          self[objs[0]][objs[1]]["enabled"].eql?(true)
-        else
-          return false if !self[feature] || self[feature].empty?
-          self[feature]["enabled"].eql?(true)
+        cur   = self
+        parts = feature.split(".")
+
+        parts.each do |part|
+          cur = cur[part]
+          return false if !cur || cur.empty?
+          return true  if cur.key?("enabled") && cur["enabled"].eql?(true)
         end
+
+        false
       end
 
       # Returns true if the given feature is disabled or doesn't exist. This is

--- a/spec/hash_utils_spec.rb
+++ b/spec/hash_utils_spec.rb
@@ -65,4 +65,14 @@ describe ::CConfig::HashUtils do
     expect(cfg["ldap"]["count"]).to eq 2          # env
     expect(cfg["ldap"]["string"]).to eq "string"  # env
   end
+
+  # See issue #3
+  it "does not crash on nested default that doesn't exist" do
+    cfg = ConfigMock.new.strict_merge_with_env_test(default: default, local: local, prefix: "test")
+
+    cfg.extend(::CConfig::HashUtils::Extensions)
+    expect(cfg.enabled?("gravatar")).to be_truthy
+    expect(cfg.enabled?("oauth.google_oauth2")).to be_falsey
+    expect(cfg.enabled?("something.that.does.not.exist")).to be_falsey
+  end
 end


### PR DESCRIPTION
A user reported a crash when you perform
`cfg.enabled?("something.another")` and `something` is a key that
doesn't exist. The fix for this has been to implement a proper general
algorithm for nested cases.

Moreover, I've updated the Gemfile.lock file, since it was still
accounting for the 1.0.0 version...

Fixes #3

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>