### PR TITLE
Let the `prefix` argument take a default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Next version
 
 - Fixed crash on nested values on the `#enabled?` method. See [#3](https://github.com/mssola/cconfig/issues/3).
+- The `prefix` argument from the constructor now takes a default
+  (`cconfig`). This will make things more predictable I hope.
 
 ## 1.1.0
 

--- a/lib/cconfig/cconfig.rb
+++ b/lib/cconfig/cconfig.rb
@@ -30,14 +30,14 @@ module CConfig
 
     # Instantiate an object with `default` as the path to the default
     # configuration, `local` as the alternate file, and `prefix` as the prefix
-    # for environment variables.
+    # for environment variables. The `prefix` will take "cconfig" as the default.
     #
     # Note: the `local` value will be discarded in favor of the
     # `#{prefix}_LOCAL_CONFIG_PATH` environment variable if it was set.
     def initialize(default:, local:, prefix:)
       @default = default
-      @local   = ENV["#{prefix.upcase}_LOCAL_CONFIG_PATH"] || local
-      @prefix  = prefix
+      @prefix  = prefix || "cconfig"
+      @local   = ENV["#{@prefix.upcase}_LOCAL_CONFIG_PATH"] || local
     end
 
     # Returns a hash with the app configuration contained in it.

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -84,9 +84,10 @@ describe CConfig::Config do
     # the local.yml file.
     base  = File.join(File.dirname(__FILE__), "fixtures")
     local = File.join(base, "bad.yml")
-    ENV["TEST_LOCAL_CONFIG_PATH"] = File.join(base, "local.yml")
+    ENV["CCONFIG_LOCAL_CONFIG_PATH"] = File.join(base, "local.yml")
 
-    cfg = ::CConfig::Config.new(default: "config.yml", local: local, prefix: "test")
+    # Passing nil to the prefix on purpose (see SUSE/Portus#1379)
+    cfg = ::CConfig::Config.new(default: "config.yml", local: local, prefix: nil)
     expect { cfg.fetch }.not_to raise_error
   end
 end


### PR DESCRIPTION
This will make things more predictable.

See SUSE/Portus#1379

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>